### PR TITLE
Set up JDK 21 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v1
+        with:
+          java-version: 21
       - name: Check Java version
         run: |
           java -version
-      # Step not needed: JDK 21 is the default on ubuntu latest
-      # - name: Set up JDK 21
-      #  uses: actions/setup-java@v1
-      #  with: 
-      #    java-version: 21
       - name: Fetch scanner cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Removed unnecessary JDK setup step since JDK 21 is default on Ubuntu latest.